### PR TITLE
Windows fix for running postinstall script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 2.2.2 (2016-03-05)
+
+- 6275233 - 2016-03-05: fix for running postinstall script on windows systems
+
+
 ## Version 2.2.1 (2015-12-20)
 
 - 0cf2051 - 2015-12-20: Ignore tooltip css in uncss

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -57,6 +57,6 @@
     "time-grunt": "1.2.2"
   },
   "scripts": {
-    "postinstall": "chmod u+x .postinstall.js && ./.postinstall.js"
+    "postinstall": "chmod u+x .postinstall.js && node ./.postinstall.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-bootstrap-kickstart",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Yeoman Generator for »Bootstrap Kickstart«",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
Calling the .postinstall.js script from node install produces an error on Windows 7 systems.
Because Windows doesn't recognize the shebang line in scripts and handles binaries with file endings associated programs. In this case (.js) with the Windows Scripting Host.

replacing the script configuration with:

```
"scripts": {
    "postinstall": "chmod u+x .postinstall.js && node ./.postinstall.js"
  }
```
it works again. The important thing here is adding 'node' before .postinstall.js, telling Windows explicit to use node.js to run the script.

Unfortunately i cannot confirm if this change breaks this on Linux or Mac Os systems.

Also read this article: [Writing cross-platform  #Node.js](http://shapeshed.com/writing-cross-platform-node/) scroll down until "Scripts in package.json", there is the problem also specified with my solution.